### PR TITLE
.hdevtoolsrc nostack CHANGELOG, README, minor edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2017
+
+ * `.hdevtoolsrc` file for project-specific configuration.
+ * Use of `stack` can be turned of with `--nostack`
+
 ## 0.1.5.0 - 2016-12-23
 
  * (Re-)added template haskell support when required. Can be turned off using `--noTH`.

--- a/README.md
+++ b/README.md
@@ -194,14 +194,34 @@ This won't work:
 
     $ hdevtools check -g '-hide-package transformers' Foo.hs
 
+In general, you will need to pass to `hdevtools` the same GHC options that you
+would pass to GHCi.
+
+For projects with custom build systems, you can prevent `hdevtools` from
+detecting a global `stack.yaml` configuration with the argument `--nostack`.
+
+#### Specifying GHC Options in Vim ####
+
 The Vim plugins allow setting GHC options in the `g:hdevtools_options`
 variable.  For example, for the above project, put the following in your
 `.vimrc`:
 
     let g:hdevtools_options = '-g -isrc -g -Wall -g -hide-package -g transformers'
 
-In general, you will need to pass to `hdevtools` the same GHC options that you
-would pass to GHCi.
+#### Specifying GHC Options with `.hdevtoolsrc` ####
+
+If an `.hdevtoolsrc` file is present, then `hdevtools` will
+parse arguments from the `.hdevtoolsrc` file before arguments from the command
+line.
+
+For example, for the above project, the `.hdevtoolsrc` file would contain:
+
+    -g -isrc -g -Wall -g -hide-package -g transformers
+
+The `.hdevtoolsrc` file will be searched for in the target path and all parents
+of the target path, or, if the `hdevtools` command has no target, in `$PWD` and
+all parents of `$PWD`.
+
 
 Credits
 -------

--- a/src/CommandArgs.hs
+++ b/src/CommandArgs.hs
@@ -289,4 +289,4 @@ loadHDevTools = do
     mConfig <- findFile (== ".hdevtoolsrc") dir
     perProject <- maybe (return []) (\f -> words <$> readFile f) mConfig
     args0 <- getArgs
-    withArgs (args0 ++ perProject) $ cmdArgs_ (full progName)
+    withArgs (perProject ++ args0) $ cmdArgs_ (full progName)

--- a/src/CommandArgs.hs
+++ b/src/CommandArgs.hs
@@ -209,7 +209,7 @@ moduleFile = record dummyModuleFile
     , cabalOpts := def += typ "OPTION"  += help "cabal options"
     , module_  := def += typ "MODULE" += argPos 0
     , debug    := def                 += help "enable debug output"
-    , noStack      := def            += help "disable stack integration"
+    , noStack  := def                 += help "disable stack integration"
     ] += help "Get the haskell source file corresponding to a module name"
 
 info :: Annotate Ann
@@ -221,7 +221,7 @@ info = record dummyInfo
     , file       := def += typFile      += argPos 0 += opt ""
     , identifier := def += typ "IDENTIFIER" += argPos 1
     , debug      := def                 += help "enable debug output"
-    , noStack      := def            += help "disable stack integration"
+    , noStack    := def                 += help "disable stack integration"
     , noTH     := def                 += help "disable template haskell"
     ] += help "Get info from GHC about the specified identifier"
 
@@ -231,7 +231,7 @@ type_ = record dummyType
     , ghcOpts  := def += typ "OPTION" += help "ghc options"
     , cabalOpts := def += typ "OPTION"  += help "cabal options"
     , debug    := def                 += help "enable debug output"
-    , noStack      := def            += help "disable stack integration"
+    , noStack  := def                 += help "disable stack integration"
     , path     := def += typFile      += help "path to target file"
     , file     := def += typFile      += argPos 0 += opt ""
     , line     := def += typ "LINE"   += argPos 1
@@ -247,7 +247,7 @@ findSymbol = record dummyFindSymbol
     , symbol   := def += typ "SYMBOL" += argPos 0
     , files    := def += typFile += args
     , debug    := def                 += help "enable debug output"
-    , noStack  := def                   += help "disable stack integration"
+    , noStack  := def                 += help "disable stack integration"
     , noTH     := def                 += help "disable template haskell"
     ] += help "List the modules where the given symbol could be found"
 


### PR DESCRIPTION
The writespace knolling commit is independent.

The CHANGELOG and README commit documents behavior of the argument ordering commit, so if the argument ordering commit is not adopted, then the CHANGELOG and README commit should be edited.